### PR TITLE
Add outline of targeted icon

### DIFF
--- a/addons/statustimers/conf_ui.lua
+++ b/addons/statustimers/conf_ui.lua
@@ -188,6 +188,12 @@ module.render_config_ui = function(settings, toggle)
                         settings.visual_aid.color25 = helpers.color_v4_to_u32(c);
                     end
                     imgui.ShowHelp('Aid colour with less than T3 seconds remaining.', true);
+
+                    c = helpers.color_u32_to_v4(settings.menu_target.outline_color);
+                    if (imgui.ColorEdit4(('\xef\x81\x9b Icon Outline'), c)) then
+                        settings.menu_target.outline_color = helpers.color_v4_to_u32(c);
+                    end
+                    imgui.ShowHelp('Status target outline colour.', true);
                 imgui.EndChild();
                 if (imgui.Button('Filter Settings')) then
                     ui.is_filters_open[1] = true;

--- a/addons/statustimers/statustimers.lua
+++ b/addons/statustimers/statustimers.lua
@@ -46,6 +46,10 @@ local default_settings = T{
         theme = '-default-',
     },
 
+    menu_target = T{
+        outline_color = 0xFFFFFF33,
+    },
+
     font = T{
         color = 0xFFFFFFFF,
         background = 0x72000000,


### PR DESCRIPTION
This implementation is scanning and reading the memory more than necessary and probably has some issues, but opening as a draft of the idea before better organizing the changes.

If you want to close this PR and use the implementation that I saw a gif of on Discord then that is fine. If you want to borrow or rework anything from this small change, go for it. I can make an adjustment, if you just want to let me know, also.

Unless I overlooked it, I didn't see the implementation for this anywhere and I can't really consider using this addon without canceling icons via keyboard, so I quickly found a pointer to the current cursor target in menus and tried a rough initial proof of concept.

What I did:
- Added function to get the current index of the cursor target in menus.
  - I would not consider myself very experienced in reverse engineering, but I know enough to figure things out enough to at least work, usually. So, I can't say for sure that this pointer is an index, but on most menus it starts from 1 and increments in order. For the menu "menu    buff    " it seems to maintain order, but that has not been extensively tested. For some menus, such as "menu    menuwind", which is the main menu opened that goes ("Status", "Equipment", ... "Region Info", "Map"), it goes mostly in order, but "Synthesis" (10) is inserted between 4 and 5 with a jump from 9 to 11. My assumption is that maybe "Synthesis" was moved at some point and the values are the index from the original order that acts as an id or they are just ids and not indexes at all.
- Added function to check the current menu name, since the pointer I used for the targeted status is seemingly used for all menus. *This function is not something I figured out on my own. I think I got it from a message by Thorny on Discord.*
- Added an outline to the targeted status icon.
  - I didn't find a way to safely prevent or modify the built-in icon targeting, but that isn't a high priority for me.
- Added a setting for the outline color, but I didn't test this, yet.

Gif of my implementation, but it is very similar to one I saw shared on the Ashita Discord:
![StatustimersIconTarget](https://github.com/HealsCodes/statustimers/assets/25873826/66e8d2a0-e67d-4998-8601-5222b18d7eb3)